### PR TITLE
Add quicksort visualization

### DIFF
--- a/quicksort/index.html
+++ b/quicksort/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" href="/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Quicksort Visualizer</title>
+  </head>
+  <body class="p-4">
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/quicksort/package.json
+++ b/quicksort/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "quicksort",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vite": "^4.0.0",
+    "tailwindcss": "^3.3.0",
+    "postcss": "^8.4.0",
+    "autoprefixer": "^10.4.0"
+  }
+}

--- a/quicksort/postcss.config.js
+++ b/quicksort/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/quicksort/src/main.ts
+++ b/quicksort/src/main.ts
@@ -1,0 +1,88 @@
+import './style.css';
+import { quicksort } from './quicksort';
+
+const app = document.querySelector<HTMLDivElement>('#app')!;
+app.innerHTML = `
+  <div class="flex flex-col items-center space-y-4">
+    <h1 class="text-2xl font-bold">Quicksort Visualizer</h1>
+    <button id="runBtn" class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded">Run</button>
+    <div id="arrayContainer" class="relative h-32 mt-4"></div>
+    <div id="status" class="mt-4 text-xl font-bold text-green-700"></div>
+  </div>
+`;
+
+const runBtn = document.getElementById('runBtn') as HTMLButtonElement;
+const arrayContainer = document.getElementById('arrayContainer') as HTMLDivElement;
+const statusEl = document.getElementById('status') as HTMLDivElement;
+
+const CELL_WIDTH = 24; // px
+const ARRAY_SIZE = 50;
+const TICK = 1000; // ms
+
+function generateArray(): number[] {
+  return Array.from({ length: ARRAY_SIZE }, () => Math.floor(Math.random() * 101));
+}
+
+function renderArray(values: number[], cells: HTMLDivElement[]) {
+  arrayContainer.style.width = `${CELL_WIDTH * ARRAY_SIZE}px`;
+  arrayContainer.innerHTML = '';
+  for (let i = 0; i < values.length; i++) {
+    const cell = document.createElement('div');
+    cell.textContent = String(values[i]);
+    cell.className = 'absolute border text-center text-xs flex items-center justify-center bg-white';
+    cell.style.width = `${CELL_WIDTH - 2}px`;
+    cell.style.height = '20px';
+    cell.style.left = `${i * CELL_WIDTH}px`;
+    cells[i] = cell;
+    arrayContainer.appendChild(cell);
+  }
+}
+
+async function animateSwap(cells: HTMLDivElement[], i: number, j: number): Promise<void> {
+  const a = cells[i];
+  const b = cells[j];
+  const dx = (j - i) * CELL_WIDTH;
+
+  const animA = a.animate(
+    [
+      { transform: 'translate(0,0)' },
+      { transform: `translate(${dx / 2}px,-40px)` },
+      { transform: `translate(${dx}px,0)` }
+    ],
+    { duration: TICK, easing: 'ease-in-out' }
+  );
+
+  const animB = b.animate(
+    [
+      { transform: 'translate(0,0)' },
+      { transform: `translate(${-dx / 2}px,40px)` },
+      { transform: `translate(${-dx}px,0)` }
+    ],
+    { duration: TICK, easing: 'ease-in-out' }
+  );
+
+  await Promise.all([animA.finished, animB.finished]);
+
+  a.style.left = `${j * CELL_WIDTH}px`;
+  b.style.left = `${i * CELL_WIDTH}px`;
+  cells[i] = b;
+  cells[j] = a;
+}
+
+async function visualize() {
+  runBtn.disabled = true;
+  statusEl.textContent = '';
+  const values = generateArray();
+  const cells: HTMLDivElement[] = new Array(values.length);
+  renderArray(values, cells);
+  const actions = quicksort([...values]);
+  for (const { i, j } of actions) {
+    await animateSwap(cells, i, j);
+  }
+  statusEl.textContent = 'Sorted';
+  runBtn.disabled = false;
+}
+
+runBtn.addEventListener('click', () => {
+  void visualize();
+});

--- a/quicksort/src/quicksort.ts
+++ b/quicksort/src/quicksort.ts
@@ -1,0 +1,33 @@
+export interface SwapAction {
+  i: number;
+  j: number;
+}
+
+export function quicksort(arr: number[]): SwapAction[] {
+  const actions: SwapAction[] = [];
+  function swap(i: number, j: number) {
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+    actions.push({ i, j });
+  }
+  function partition(lo: number, hi: number): number {
+    const pivot = arr[hi];
+    let i = lo;
+    for (let j = lo; j < hi; j++) {
+      if (arr[j] < pivot) {
+        swap(i, j);
+        i++;
+      }
+    }
+    swap(i, hi);
+    return i;
+  }
+  function qs(lo: number, hi: number) {
+    if (lo < hi) {
+      const p = partition(lo, hi);
+      qs(lo, p - 1);
+      qs(p + 1, hi);
+    }
+  }
+  qs(0, arr.length - 1);
+  return actions;
+}

--- a/quicksort/src/style.css
+++ b/quicksort/src/style.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/quicksort/tailwind.config.js
+++ b/quicksort/tailwind.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  content: [
+    './index.html',
+    './src/**/*.{ts,tsx,js,jsx,html}'
+  ],
+  theme: {
+    extend: {}
+  },
+  plugins: []
+};

--- a/quicksort/tsconfig.json
+++ b/quicksort/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "jsx": "preserve",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "lib": ["DOM", "ESNext"],
+    "types": ["vite/client"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/quicksort/vite.config.ts
+++ b/quicksort/vite.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vite';
+import path from 'path';
+
+export default defineConfig({
+  root: '.',
+  build: {
+    outDir: 'dist'
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src')
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- implement instrumented quicksort with `SwapAction`
- build a simple UI with a Run button that animates swaps

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_687d8b55febc83239450311433cdd99c