### PR TITLE
Add quicksort visualization improvements

### DIFF
--- a/quicksort/index.html
+++ b/quicksort/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" href="/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Quicksort Visualizer</title>
+  </head>
+  <body class="p-4">
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/quicksort/package.json
+++ b/quicksort/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "quicksort",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vite": "^4.0.0",
+    "tailwindcss": "^3.3.0",
+    "postcss": "^8.4.0",
+    "autoprefixer": "^10.4.0"
+  }
+}

--- a/quicksort/postcss.config.js
+++ b/quicksort/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/quicksort/src/main.ts
+++ b/quicksort/src/main.ts
@@ -1,0 +1,147 @@
+import './style.css';
+import { quicksort, Action } from './quicksort';
+
+const app = document.querySelector<HTMLDivElement>('#app')!;
+app.innerHTML = `
+  <div class="flex flex-col items-center space-y-8">
+    <h1 class="text-2xl font-bold">Quicksort Visualizer</h1>
+    <button id="runBtn" class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded">Run</button>
+    <div id="arrayContainer" class="relative h-32"></div>
+    <div id="status" class="mt-4 text-xl font-bold text-green-700"></div>
+  </div>
+`;
+
+const runBtn = document.getElementById('runBtn') as HTMLButtonElement;
+const arrayContainer = document.getElementById('arrayContainer') as HTMLDivElement;
+const statusEl = document.getElementById('status') as HTMLDivElement;
+let highlightEl: HTMLDivElement;
+let iLabel: HTMLDivElement;
+let jLabel: HTMLDivElement;
+let pLabel: HTMLDivElement;
+
+const CELL_WIDTH = 32; // px - wider cells
+const GAP = 4; // space between cells
+const ARRAY_SIZE = 30;
+const TICK = 1000; // ms
+
+function generateArray(): number[] {
+  return Array.from({ length: ARRAY_SIZE }, () => Math.floor(Math.random() * 101));
+}
+
+function renderArray(values: number[], cells: HTMLDivElement[]) {
+  const totalWidth = ARRAY_SIZE * CELL_WIDTH + (ARRAY_SIZE - 1) * GAP;
+  arrayContainer.style.width = `${totalWidth}px`;
+  arrayContainer.innerHTML = '';
+
+  highlightEl = document.createElement('div');
+  highlightEl.className = 'absolute top-0 h-8 bg-yellow-300 opacity-50 rounded';
+  highlightEl.style.transition = `left ${TICK}ms ease, width ${TICK}ms ease`;
+  highlightEl.style.width = '0px';
+  arrayContainer.appendChild(highlightEl);
+
+  for (let i = 0; i < values.length; i++) {
+    const cell = document.createElement('div');
+    cell.textContent = String(values[i]);
+    cell.className = 'absolute border text-center text-xs flex items-center justify-center bg-white';
+    cell.style.width = `${CELL_WIDTH - 2}px`;
+    cell.style.height = '24px';
+    cell.style.left = `${i * (CELL_WIDTH + GAP)}px`;
+    cells[i] = cell;
+    arrayContainer.appendChild(cell);
+  }
+
+  iLabel = document.createElement('div');
+  iLabel.textContent = 'i';
+  iLabel.className = 'absolute text-xs font-bold text-red-600';
+  iLabel.style.top = '24px';
+  iLabel.style.transform = 'translateX(-50%)';
+  iLabel.style.transition = `left ${TICK}ms ease`;
+  arrayContainer.appendChild(iLabel);
+
+  jLabel = document.createElement('div');
+  jLabel.textContent = 'j';
+  jLabel.className = 'absolute text-xs font-bold text-blue-600';
+  jLabel.style.top = '36px';
+  jLabel.style.transform = 'translateX(-50%)';
+  jLabel.style.transition = `left ${TICK}ms ease`;
+  arrayContainer.appendChild(jLabel);
+
+  pLabel = document.createElement('div');
+  pLabel.textContent = 'p';
+  pLabel.className = 'absolute text-xs font-bold text-purple-600';
+  pLabel.style.top = '48px';
+  pLabel.style.transform = 'translateX(-50%)';
+  pLabel.style.transition = `left ${TICK}ms ease`;
+  arrayContainer.appendChild(pLabel);
+}
+
+async function animateSwap(cells: HTMLDivElement[], i: number, j: number): Promise<void> {
+  const a = cells[i];
+  const b = cells[j];
+  const dx = (j - i) * (CELL_WIDTH + GAP);
+
+  const animA = a.animate(
+    [
+      { transform: 'translate(0,0)' },
+      { transform: `translate(${dx / 2}px,-40px)` },
+      { transform: `translate(${dx}px,0)` }
+    ],
+    { duration: TICK, easing: 'ease-in-out' }
+  );
+
+  const animB = b.animate(
+    [
+      { transform: 'translate(0,0)' },
+      { transform: `translate(${-dx / 2}px,40px)` },
+      { transform: `translate(${-dx}px,0)` }
+    ],
+    { duration: TICK, easing: 'ease-in-out' }
+  );
+
+  await Promise.all([animA.finished, animB.finished]);
+
+  a.style.left = `${j * (CELL_WIDTH + GAP)}px`;
+  b.style.left = `${i * (CELL_WIDTH + GAP)}px`;
+  cells[i] = b;
+  cells[j] = a;
+}
+
+function wait(ms: number) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function processActions(actions: Action[], cells: HTMLDivElement[]) {
+  for (const act of actions) {
+    if (act.type === 'swap') {
+      await animateSwap(cells, act.i, act.j);
+    } else if (act.type === 'pointer') {
+      const label = act.name === 'i' ? iLabel : act.name === 'j' ? jLabel : pLabel;
+      label.style.left = `${act.index * (CELL_WIDTH + GAP) + CELL_WIDTH / 2}px`;
+      await wait(TICK);
+    } else if (act.type === 'range') {
+      if (act.hi < act.lo) {
+        highlightEl.style.width = '0px';
+      } else {
+        highlightEl.style.left = `${act.lo * (CELL_WIDTH + GAP)}px`;
+        highlightEl.style.width = `${(act.hi - act.lo + 1) * (CELL_WIDTH + GAP) - GAP}px`;
+      }
+      await wait(TICK);
+    }
+  }
+}
+
+async function visualize() {
+  runBtn.disabled = true;
+  statusEl.textContent = '';
+  const values = generateArray();
+  const cells: HTMLDivElement[] = new Array(values.length);
+  renderArray(values, cells);
+  const actions = quicksort([...values]);
+  await processActions(actions, cells);
+  statusEl.textContent = 'Sorted';
+  runBtn.disabled = false;
+}
+
+runBtn.addEventListener('click', () => {
+  void visualize();
+});

--- a/quicksort/src/quicksort.ts
+++ b/quicksort/src/quicksort.ts
@@ -1,0 +1,56 @@
+export type Action =
+  | { type: 'swap'; i: number; j: number }
+  | { type: 'range'; lo: number; hi: number }
+  | { type: 'pointer'; name: 'i' | 'j' | 'p'; index: number };
+
+export function quicksort(arr: number[]): Action[] {
+  const actions: Action[] = [];
+
+  function recordPointer(name: 'i' | 'j' | 'p', index: number) {
+    actions.push({ type: 'pointer', name, index });
+  }
+
+  function setRange(lo: number, hi: number) {
+    actions.push({ type: 'range', lo, hi });
+  }
+
+  function swap(i: number, j: number) {
+    if (i === j) return; // avoid self swaps
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+    actions.push({ type: 'swap', i, j });
+  }
+
+  function partition(lo: number, hi: number): number {
+    setRange(lo, hi);
+    const pivot = arr[hi];
+    recordPointer('p', hi);
+    let i = lo;
+    recordPointer('i', i);
+    for (let j = lo; j < hi; j++) {
+      recordPointer('j', j);
+      if (arr[j] < pivot) {
+        swap(i, j);
+        i++;
+        recordPointer('i', i);
+      }
+    }
+    recordPointer('j', hi);
+    swap(i, hi);
+    recordPointer('p', i);
+    return i;
+  }
+
+  function qs(lo: number, hi: number) {
+    if (lo < hi) {
+      const p = partition(lo, hi);
+      qs(lo, p - 1);
+      qs(p + 1, hi);
+    } else if (lo <= hi) {
+      setRange(lo, hi);
+    }
+  }
+
+  qs(0, arr.length - 1);
+  setRange(0, -1); // clear highlight
+  return actions;
+}

--- a/quicksort/src/style.css
+++ b/quicksort/src/style.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/quicksort/tailwind.config.js
+++ b/quicksort/tailwind.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  content: [
+    './index.html',
+    './src/**/*.{ts,tsx,js,jsx,html}'
+  ],
+  theme: {
+    extend: {}
+  },
+  plugins: []
+};

--- a/quicksort/tsconfig.json
+++ b/quicksort/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "jsx": "preserve",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "lib": ["DOM", "ESNext"],
+    "types": ["vite/client"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/quicksort/vite.config.ts
+++ b/quicksort/vite.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vite';
+import path from 'path';
+
+export default defineConfig({
+  root: '.',
+  build: {
+    outDir: 'dist'
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src')
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- expand pointer actions to include pivot tracking
- darken highlight and center position labels
- space out the page elements

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_687d8b55febc83239450311433cdd99c