### PR TITLE
Improve quicksort visualization

### DIFF
--- a/quicksort/README.md
+++ b/quicksort/README.md
@@ -1,0 +1,18 @@
+# Quicksort Visualizer
+
+This project is a simple client-side application that visualizes how the quicksort algorithm works. It builds on Vite for development and bundling and uses Tailwind CSS for styling.
+
+When you click **Show Quicksort**, a random array of 30 numbers is generated and the algorithm sorts it while animating each step. You can adjust the tick slider to control the animation speed.
+
+## Development
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Start the development server:
+   ```bash
+   npm run dev
+   ```
+
+Then open the provided local URL in your browser to see the visualization.

--- a/quicksort/index.html
+++ b/quicksort/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" href="/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Quicksort Visualizer</title>
+  </head>
+  <body class="p-4">
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/quicksort/package.json
+++ b/quicksort/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "quicksort",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vite": "^4.0.0",
+    "tailwindcss": "^3.3.0",
+    "postcss": "^8.4.0",
+    "autoprefixer": "^10.4.0"
+  }
+}

--- a/quicksort/postcss.config.js
+++ b/quicksort/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/quicksort/src/main.ts
+++ b/quicksort/src/main.ts
@@ -1,0 +1,224 @@
+import './style.css';
+import { quicksort, Action } from './quicksort';
+
+const app = document.querySelector<HTMLDivElement>('#app')!;
+app.innerHTML = `
+  <div class="flex flex-col items-center space-y-8">
+    <h1 class="text-2xl font-bold">Quicksort Visualizer</h1>
+    <div class="flex items-center space-x-4">
+      <button id="runBtn" class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded">Show Quicksort</button>
+      <input id="tickSlider" type="range" min="0" max="1" step="0.01" value="0" class="w-32" />
+    </div>
+    <div id="arrayContainer" class="relative h-80"></div>
+  </div>
+`;
+
+const runBtn = document.getElementById('runBtn') as HTMLButtonElement;
+const arrayContainer = document.getElementById('arrayContainer') as HTMLDivElement;
+const tickSlider = document.getElementById('tickSlider') as HTMLInputElement;
+let iLabel: HTMLDivElement | null = null;
+let jLabel: HTMLDivElement | null = null;
+let pLabel: HTMLDivElement | null = null;
+
+const CELL_WIDTH = 32; // px - wider cells
+const GAP = 4; // space between cells
+const ARRAY_SIZE = 30;
+let tickMs = 1000; // default tick length
+
+function computeTickMs() {
+  const sliderVal = parseFloat(tickSlider.value);
+  return ((1 - sliderVal) * 0.8 + 0.2) * 1000;
+}
+tickMs = computeTickMs();
+tickSlider.addEventListener('input', () => {
+  tickMs = computeTickMs();
+});
+const LEVEL_OFFSET = 32; // vertical offset per recursion level
+const POINTER_BASES = { i: 24, j: 36, p: 48 } as const;
+
+function createPointer(name: 'i' | 'j' | 'p'): HTMLDivElement {
+  const div = document.createElement('div');
+  div.textContent = name;
+  div.className =
+    'absolute text-xs font-bold ' +
+    (name === 'i'
+      ? 'text-red-600'
+      : name === 'j'
+      ? 'text-blue-600'
+      : 'text-purple-600');
+  div.style.transform = 'translateX(-50%)';
+  div.style.transition = `left ${tickMs * 0.5}ms ease, top ${tickMs * 0.5}ms ease, opacity ${tickMs * 0.5}ms`;
+  return div;
+}
+
+function generateArray(): number[] {
+  return Array.from({ length: ARRAY_SIZE }, () => Math.floor(Math.random() * 101));
+}
+
+function renderArray(values: number[], cells: HTMLDivElement[]) {
+  const totalWidth = ARRAY_SIZE * CELL_WIDTH + (ARRAY_SIZE - 1) * GAP;
+  arrayContainer.style.width = `${totalWidth}px`;
+  arrayContainer.innerHTML = '';
+
+
+  for (let i = 0; i < values.length; i++) {
+    const cell = document.createElement('div');
+    cell.textContent = String(values[i]);
+    cell.className = 'absolute border text-center text-xs flex items-center justify-center bg-white';
+    cell.style.width = `${CELL_WIDTH - 2}px`;
+    cell.style.height = '24px';
+    cell.style.left = `${i * (CELL_WIDTH + GAP)}px`;
+    cell.style.top = '0px';
+    cell.style.transition = `top ${tickMs}ms ease`;
+    cells[i] = cell;
+    arrayContainer.appendChild(cell);
+  }
+
+  iLabel = createPointer('i');
+  iLabel.style.top = '24px';
+  arrayContainer.appendChild(iLabel);
+
+  jLabel = createPointer('j');
+  jLabel.style.top = '36px';
+  arrayContainer.appendChild(jLabel);
+
+  pLabel = createPointer('p');
+  pLabel.style.top = '48px';
+  arrayContainer.appendChild(pLabel);
+}
+
+async function animateSwap(cells: HTMLDivElement[], i: number, j: number): Promise<void> {
+  const a = cells[i];
+  const b = cells[j];
+  const dx = (j - i) * (CELL_WIDTH + GAP);
+  tickMs = computeTickMs();
+
+  const animA = a.animate(
+    [
+      { transform: 'translate(0,0)' },
+      { transform: `translate(${dx / 2}px,-40px)` },
+      { transform: `translate(${dx}px,0)` }
+    ],
+    { duration: tickMs, easing: 'ease-in-out' }
+  );
+
+  const animB = b.animate(
+    [
+      { transform: 'translate(0,0)' },
+      { transform: `translate(${-dx / 2}px,40px)` },
+      { transform: `translate(${-dx}px,0)` }
+    ],
+    { duration: tickMs, easing: 'ease-in-out' }
+  );
+
+  await Promise.all([animA.finished, animB.finished]);
+
+  a.style.left = `${j * (CELL_WIDTH + GAP)}px`;
+  b.style.left = `${i * (CELL_WIDTH + GAP)}px`;
+  cells[i] = b;
+  cells[j] = a;
+}
+
+function wait(ms: number) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function processActions(actions: Action[], cells: HTMLDivElement[]) {
+  const levels = new Array(cells.length).fill(0);
+  for (const act of actions) {
+    tickMs = computeTickMs();
+    if (act.type === 'swap') {
+      await animateSwap(cells, act.i, act.j);
+    } else if (act.type === 'pointer') {
+      let label: HTMLDivElement | null = null;
+      if (act.name === 'i') {
+        if (!iLabel) {
+          iLabel = createPointer('i');
+          arrayContainer.appendChild(iLabel);
+        }
+        label = iLabel;
+      } else if (act.name === 'j') {
+        if (!jLabel) {
+          jLabel = createPointer('j');
+          arrayContainer.appendChild(jLabel);
+        }
+        label = jLabel;
+      } else {
+        if (!pLabel) {
+          pLabel = createPointer('p');
+          arrayContainer.appendChild(pLabel);
+        }
+        label = pLabel;
+      }
+      label.style.transition = `left ${tickMs * 0.5}ms ease, top ${tickMs * 0.5}ms ease, opacity ${tickMs * 0.5}ms`;
+      if (act.name === 'p') {
+        if (iLabel) iLabel.style.visibility = 'hidden';
+        if (jLabel) jLabel.style.visibility = 'hidden';
+      } else {
+        if (iLabel) iLabel.style.visibility = 'visible';
+        if (jLabel) jLabel.style.visibility = 'visible';
+      }
+      label.style.opacity = '1';
+      label.style.left = `${act.index * (CELL_WIDTH + GAP) + CELL_WIDTH / 2}px`;
+      const base = POINTER_BASES[act.name];
+      label.style.top = `${base + act.level * LEVEL_OFFSET}px`;
+      await wait(tickMs / 2);
+    }
+    else if (act.type === 'level') {
+      for (let idx = act.lo; idx <= act.hi; idx++) {
+        cells[idx].style.transition = `top ${tickMs * 0.5}ms ease`;
+        cells[idx].style.top = `${act.level * LEVEL_OFFSET}px`;
+        levels[idx] = act.level;
+      }
+      await wait(tickMs / 2);
+    } else if (act.type === 'prepare') {
+      if (iLabel) iLabel.style.opacity = '0';
+      if (jLabel) jLabel.style.opacity = '0';
+      if (pLabel) pLabel.style.opacity = '0';
+      await wait(tickMs);
+      if (iLabel) { iLabel.remove(); iLabel = null; }
+      if (jLabel) { jLabel.remove(); jLabel = null; }
+      if (pLabel) { pLabel.remove(); pLabel = null; }
+      cells[act.pivot].style.background = '#bfdbfe';
+    } else if (act.type === 'collapse') {
+      for (let idx = 0; idx < levels.length; idx++) {
+        if (levels[idx] === act.level) {
+          cells[idx].style.transition = `top ${tickMs}ms ease`;
+          cells[idx].style.top = `${(act.level - 1) * LEVEL_OFFSET}px`;
+          levels[idx] = act.level - 1;
+        }
+      }
+      await wait(tickMs);
+    }
+  }
+
+  for (const cell of cells) {
+    if (cell.style.background) {
+      cell.style.transition = `background-color ${tickMs * 2}ms ease`;
+      cell.style.background = '';
+    }
+  }
+  await wait(tickMs * 2);
+}
+
+async function visualize() {
+  runBtn.disabled = true;
+  runBtn.textContent = 'Sorting ...';
+  runBtn.classList.add('cursor-not-allowed');
+  tickMs = computeTickMs();
+  const values = generateArray();
+  const cells: HTMLDivElement[] = new Array(values.length);
+  renderArray(values, cells);
+  const actions = quicksort([...values]);
+  await processActions(actions, cells);
+  if (iLabel) { iLabel.remove(); iLabel = null; }
+  if (jLabel) { jLabel.remove(); jLabel = null; }
+  if (pLabel) { pLabel.remove(); pLabel = null; }
+  runBtn.textContent = 'Show Quicksort';
+  runBtn.classList.remove('cursor-not-allowed');
+  runBtn.disabled = false;
+}
+
+runBtn.addEventListener('click', () => {
+  void visualize();
+});

--- a/quicksort/src/quicksort.ts
+++ b/quicksort/src/quicksort.ts
@@ -1,0 +1,81 @@
+export type Action =
+  | { type: 'swap'; i: number; j: number }
+  | { type: 'level'; lo: number; hi: number; level: number }
+  | { type: 'pointer'; name: 'i' | 'j' | 'p'; index: number; level: number }
+  | { type: 'prepare'; pivot: number }
+  | { type: 'collapse'; level: number };
+
+export function quicksort(arr: number[]): Action[] {
+  const actions: Action[] = [];
+  let maxLevel = 0;
+
+  function recordPointer(name: 'i' | 'j' | 'p', index: number, level: number) {
+    actions.push({ type: 'pointer', name, index, level });
+  }
+
+  function setLevel(lo: number, hi: number, level: number) {
+    if (hi < lo) return;
+    if (level > maxLevel) maxLevel = level;
+    actions.push({ type: 'level', lo, hi, level });
+  }
+
+  function swap(i: number, j: number) {
+    if (i === j) return; // avoid self swaps
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+    actions.push({ type: 'swap', i, j });
+  }
+
+  function partition(lo: number, hi: number, level: number): number {
+    const pivotIndex = lo;
+    const pivot = arr[pivotIndex];
+    recordPointer('p', pivotIndex, level);
+    let i = lo + 1;
+    let j = hi;
+    recordPointer('i', i, level);
+    recordPointer('j', j, level);
+
+    while (true) {
+      while (i <= hi && arr[i] <= pivot) {
+        recordPointer('i', i, level);
+        i++;
+      }
+      recordPointer('i', i, level);
+
+      while (j >= lo + 1 && arr[j] >= pivot) {
+        recordPointer('j', j, level);
+        j--;
+      }
+      recordPointer('j', j, level);
+
+      if (i >= j) break;
+
+      swap(i, j);
+      i++;
+      j--;
+      recordPointer('i', i, level);
+      recordPointer('j', j, level);
+    }
+
+    swap(pivotIndex, j);
+    recordPointer('p', j, level);
+    return j;
+  }
+
+  function qs(lo: number, hi: number, level: number) {
+    if (lo > hi) return;
+    setLevel(lo, hi, level);
+    if (lo < hi) {
+      const p = partition(lo, hi, level);
+      actions.push({ type: 'prepare', pivot: p });
+      qs(lo, p - 1, level + 1);
+      actions.push({ type: 'prepare', pivot: p });
+      qs(p + 1, hi, level + 1);
+    }
+  }
+
+  qs(0, arr.length - 1, 0);
+  for (let l = maxLevel; l >= 1; l--) {
+    actions.push({ type: 'collapse', level: l });
+  }
+  return actions;
+}

--- a/quicksort/src/style.css
+++ b/quicksort/src/style.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/quicksort/tailwind.config.js
+++ b/quicksort/tailwind.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  content: [
+    './index.html',
+    './src/**/*.{ts,tsx,js,jsx,html}'
+  ],
+  theme: {
+    extend: {}
+  },
+  plugins: []
+};

--- a/quicksort/tsconfig.json
+++ b/quicksort/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "jsx": "preserve",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "lib": ["DOM", "ESNext"],
+    "types": ["vite/client"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/quicksort/vite.config.ts
+++ b/quicksort/vite.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vite';
+import path from 'path';
+
+export default defineConfig({
+  root: '.',
+  build: {
+    outDir: 'dist'
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src')
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- allow tick slider to slow the animation when dragged left
- track recursion depth with new actions and leave segments in place
- fade pointers before each child recursion and reappear at the new level
- return all segments to the top once sorting finishes
- update Hoare-style partitioning
- fade out highlighted cells after sorting
- document project in quicksort/README.md

## Testing
- `npm run build` *(fails: vite not found)*
- `npx tsc --noEmit` *(fails: 403 Forbidden when fetching tsc)*

------
https://chatgpt.com/codex/tasks/task_b_687d8b55febc83239450311433cdd99c